### PR TITLE
Major Performance Improvement

### DIFF
--- a/pascal5i_reader.py
+++ b/pascal5i_reader.py
@@ -102,10 +102,13 @@ class Pascal5iReader(torchvision.datasets.vision.VisionDataset):
         # Given an index of an image, this dict returns list of classes in the image
         self.img_class_map = {}
         
-        if os.path.exists("dataset_icm.pt") and os.path.exists("dataset_cim.pt"):
+        if os.path.exists("dataset.pt"):
 			print('Using Saved Dataset')
-			self.img_class_map = torch.load("dataset_icm.pt")
-			self.class_img_map = torch.load("dataset_cim.pt")
+			d = torch.load("dataset.pt")
+			self.img_class_map = d['icm'] 
+			self.class_img_map = d['cim']
+			folded_images = d['fi']
+			folded_targets = d['ft']
 		else:
 			print('Creating Dataset')
 			for i in tqdm(range(len(self.images))):
@@ -126,8 +129,12 @@ class Pascal5iReader(torchvision.datasets.vision.VisionDataset):
 							self.img_class_map[cur_img_id].append(cur_class_id)
 						else:
 							self.img_class_map[cur_img_id] = [cur_class_id]
-			torch.save(self.img_class_map, "dataset_icm.pt")
-			torch.save(self.class_img_map, "dataset_cim.pt")
+			torch.save({
+				'icm':self.img_class_map, 
+				'cim':self.class_img_map,
+				'fi': folded_images,
+				'ft': folded_targets
+			}, "dataset.pt")
 
         self.images = folded_images
         self.targets = folded_targets

--- a/pascal5i_reader.py
+++ b/pascal5i_reader.py
@@ -4,10 +4,10 @@ Module containing reader to parse pascal_5i dataset from SBD and VOC2012
 import os
 from PIL import Image
 from scipy.io import loadmat
+from tqdm import trange
 import numpy as np
 import torch
 import torchvision
-
 
 class Pascal5iReader(torchvision.datasets.vision.VisionDataset):
     """
@@ -103,38 +103,38 @@ class Pascal5iReader(torchvision.datasets.vision.VisionDataset):
         self.img_class_map = {}
         
         if os.path.exists("dataset.pt"):
-			print('Using Saved Dataset')
-			d = torch.load("dataset.pt")
-			self.img_class_map = d['icm'] 
-			self.class_img_map = d['cim']
-			folded_images = d['fi']
-			folded_targets = d['ft']
-		else:
-			print('Creating Dataset')
-			for i in tqdm(range(len(self.images))):
-				mask = self.load_seg_mask(self.targets[i])
-				appended_flag = False
-				for label_id, x in enumerate(self.label_set):
-					if x in mask:
-						if not appended_flag:
-							# contain at least one pixel in L_{train}
-							folded_images.append(self.images[i])
-							folded_targets.append(self.targets[i])
-							appended_flag = True
-						cur_img_id = len(folded_images) - 1
-						cur_class_id = label_id + 1
-						# This image must be the latest appended image
-						self.class_img_map[cur_class_id].append(cur_img_id)
-						if cur_img_id in self.img_class_map:
-							self.img_class_map[cur_img_id].append(cur_class_id)
-						else:
-							self.img_class_map[cur_img_id] = [cur_class_id]
-			torch.save({
-				'icm':self.img_class_map, 
-				'cim':self.class_img_map,
-				'fi': folded_images,
-				'ft': folded_targets
-			}, "dataset.pt")
+            print('Using saved class mapping')
+            d = torch.load("dataset.pt")
+            self.img_class_map = d['icm']
+            self.class_img_map = d['cim']
+            folded_images = d['fi']
+            folded_targets = d['ft']
+        else:
+            print('Creating Dataset')
+            for i in trange(len(self.images)):
+                mask = self.load_seg_mask(self.targets[i])
+                appended_flag = False
+                for label_id, x in enumerate(self.label_set):
+                    if x in mask:
+                        if not appended_flag:
+                            # contain at least one pixel in L_{train}
+                            folded_images.append(self.images[i])
+                            folded_targets.append(self.targets[i])
+                            appended_flag = True
+                        cur_img_id = len(folded_images) - 1
+                        cur_class_id = label_id + 1
+                        # This image must be the latest appended image
+                        self.class_img_map[cur_class_id].append(cur_img_id)
+                        if cur_img_id in self.img_class_map:
+                            self.img_class_map[cur_img_id].append(cur_class_id)
+                        else:
+                            self.img_class_map[cur_img_id] = [cur_class_id]
+            torch.save({
+                'icm':self.img_class_map, 
+                'cim':self.class_img_map,
+                'fi': folded_images,
+                'ft': folded_targets
+            }, "dataset.pt")
 
         self.images = folded_images
         self.targets = folded_targets


### PR DESCRIPTION
The `for` loop at line https://github.com/RogerQi/pascal-5i/blob/d570d80c1c8a48249a16e4496476fd6862cf973d/pascal5i_reader.py#L105 usually takes 2 mins and 30 seconds on my device to run, which is... slow. However, those maps are essential for few-shot (obv). So, we can save them to a file when we create them once and load them back almost instantly every other time (after checking that the file exists).

Small change but a big improvement

And thank you for writing such a nice dataloader! Took me <5 mins to integrate with my project!